### PR TITLE
Only use a single type for holding configuration (secrets)

### DIFF
--- a/NowWhat/CLI.fs
+++ b/NowWhat/CLI.fs
@@ -22,7 +22,7 @@ let nowwhat argv =
     | Forecast.FailedException(string) ->
       printfn $"Error retrieving Forecast data: {string}"
       -2
-    | Config.SecretLoadException(string) ->
+    | Config.LoadException(string) ->
       printfn $"Error loading secrets: {string}"
       -3
     | other ->

--- a/NowWhat/api/Forecast.fs
+++ b/NowWhat/api/Forecast.fs
@@ -62,7 +62,7 @@ let rootDecoder : Decoder<Root> =
 let [<Literal>] ForecastUrl = "https://api.forecastapp.com/"
 
 let forecastRequest (endpoint: string): string =
-  let secrets = match getSecrets () with
+  let secrets = match getConfig () with
                 | Ok secrets -> secrets
                 | Error err -> raise (FailedException("Forecast secrets could not be loaded. {err.ToString()}"))
   let response = Request.createUrl Get (ForecastUrl + endpoint)

--- a/NowWhat/api/Github.fs
+++ b/NowWhat/api/Github.fs
@@ -128,7 +128,7 @@ let formatQuery (q: string) = q.Replace("\n", "")
 
 let getProjectIssues (projectName: string): Issue List =
   // the parent function is only wrapping up the recursive call that deals with paging of the responses
-  let githubToken = match getSecrets () with
+  let githubToken = match getConfig () with
                     | Ok secrets -> secrets.githubToken
                     | Error err -> raise err
 


### PR DESCRIPTION
 - Drop type Secrets in favour of Config
 - Config to use camel case as in secrets.json