### PR TITLE
Revert Config.getConfig () to return a simple type (not a Result)

### DIFF
--- a/NowWhat/Config.fs
+++ b/NowWhat/Config.fs
@@ -53,9 +53,6 @@ let lazyConfig =
 
 /// Return server credentials from either environment variables (if defined) or
 /// a config file. The file will only be read once.
-let getConfig (): Result<Config, exn> =
-    try
-      let config = lazyConfig.Force()
-      Ok config
-    with
-    | e -> Error e
+let getConfig () = 
+      lazyConfig.Force()
+      

--- a/NowWhat/api/Forecast.fs
+++ b/NowWhat/api/Forecast.fs
@@ -55,10 +55,7 @@ let ForecastUrl = "https://api.forecastapp.com/"
 
 let forecastRequest (endpoint: string) : string =
 
-    let secrets =
-        match getConfig () with
-        | Ok secrets -> secrets
-        | Error err -> raise (FailedException($"Forecast secrets could not be loaded. {err.ToString()}"))
+    let secrets = getConfig () 
 
     let response =
         Request.createUrl Get (ForecastUrl + endpoint)

--- a/NowWhat/api/Github.fs
+++ b/NowWhat/api/Github.fs
@@ -95,10 +95,7 @@ let formatQuery (q: string) = q.Replace("\n", "")
 
 let getProjectIssues (projectName: string) : Issue List =
     // the parent function is only wrapping up the recursive call that deals with paging of the responses
-    let githubToken =
-        match getConfig () with
-        | Ok secrets -> secrets.githubToken
-        | Error err -> raise err
+    let githubToken = (getConfig ()).githubToken 
 
     let rec getProjectIssues_page (projectName: string) cursor (acc: (Issue * string) List) =
         let queryTemplate =


### PR DESCRIPTION
Because if a failure had already occured, then an exception
would already have been raised.